### PR TITLE
Cut the screenshot at 410px height instead of 460px height, to strip navigation

### DIFF
--- a/TeletekstBot.Infrastructure/Services/FetchPageDetailsFromNos.cs
+++ b/TeletekstBot.Infrastructure/Services/FetchPageDetailsFromNos.cs
@@ -20,7 +20,7 @@ public class FetchPageDetailsFromNos : IFetchPageDetailsFromNos
     
     // Clip of the area we want to screenshot
     private const int ClipWidth = 370;
-    private const int ClipHeight = 460;
+    private const int ClipHeight = 410;
     private const int ClipStartX = 40;
     private const int ClipStartY = 330;
     


### PR DESCRIPTION
At the moment every screenshot has the 'Volgende', 'Nieuws', 'Weer&Verkeer' and 'Sport' navigation at the bottom. It takes unnecessary space in the Bluesky timeline.