### PR TITLE
Strip HTML tags from original Teletekst title

### DIFF
--- a/TeletekstBot.Infrastructure/Services/TeletekstHtmlParser.cs
+++ b/TeletekstBot.Infrastructure/Services/TeletekstHtmlParser.cs
@@ -76,6 +76,7 @@ public partial class TeletekstHtmlParser : ITeletekstHtmlParser
         }
 
         var titleText = titleNode.InnerText.Trim();
+	titleText = Regex.Replace(titleText, "<.*?>", String.Empty);
 
         return WebUtility.HtmlDecode(titleText);
     }


### PR DESCRIPTION
Some posts contain HTML tags in the title. Strip those tags before using the title.
Example: https://bsky.app/profile/teletekstbot.bsky.social/post/3k52kiboeel2f

Linked to issue #2 