### PR TITLE
Remove trailing periods in title #5

### DIFF
--- a/TeletekstBot.Infrastructure/Services/TeletekstHtmlParser.cs
+++ b/TeletekstBot.Infrastructure/Services/TeletekstHtmlParser.cs
@@ -81,6 +81,8 @@ public partial class TeletekstHtmlParser : ITeletekstHtmlParser
         
         var titleText = WebUtility.HtmlDecode(titleNode.InnerText.Trim());
         titleText = RemoveHtmlEntities(titleText);
+        
+        titleText = titleText.TrimEnd('.').Trim();
 
         return titleText;
         

--- a/TeletekstBot.Tests/MockFiles/full_nos_page_110_with_html_entities_in_title.html
+++ b/TeletekstBot.Tests/MockFiles/full_nos_page_110_with_html_entities_in_title.html
@@ -205,7 +205,7 @@
 
         <div class="teletekst__content js-tt-content"><pre class="teletekst__content__pre">                     <span class="green "> NOS Teletekst</span><span class="yellow "> <a class="yellow" href="#110">110</a> </span>
 <span class="yellow ">&#xF020;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;</span>
-<span class="blue bg-blue "> </span><span class="blue bg-blue doubleHeight "> </span><span class="yellow bg-blue doubleHeight "> Miss Universe breekt met Indonesi&euml;  </span>
+<span class="blue bg-blue "> </span><span class="blue bg-blue doubleHeight "> </span><span class="yellow bg-blue doubleHeight "> Miss Universe breekt met Indonesi&euml; ... </span>
 
 <span class="yellow ">&#xF020;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;&#xF02c;</span>
 <span class="yellow ">&#xF020;&#xF02f;</span>


### PR DESCRIPTION
This commit fixes the issue with trailing periods in the title.